### PR TITLE
FIX: regenerate headers for Boost 1.75.0 with patch files applied

### DIFF
--- a/boost/math/tools/config.hpp
+++ b/boost/math/tools/config.hpp
@@ -28,7 +28,7 @@
 
 #include <boost/math/tools/user.hpp>
 
-#if (defined(__CYGWIN__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__EMSCRIPTEN__)\
+#if (defined(__NetBSD__) || defined(__EMSCRIPTEN__)\
    || (defined(__hppa) && !defined(__OpenBSD__)) || (defined(__NO_LONG_DOUBLE_MATH) && (DBL_MANT_DIG != LDBL_MANT_DIG))) \
    && !defined(BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS)
 #  define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS


### PR DESCRIPTION
https://github.com/scipy/boost-headers-only/pull/5 added a patch file, but the headers were not regenerated.  This PR captures the result of running `python make_headers.py --boost-version 1.75.0` on current main branch.