### PR TITLE
FIX: add upstream beta underflow patch

### DIFF
--- a/boost/math/special_functions/beta.hpp
+++ b/boost/math/special_functions/beta.hpp
@@ -390,7 +390,7 @@ T ibeta_power_terms(T a,
          else
          {
             T p1 = pow(b1, a / b);
-            T l3 = (log(p1) + log(b2)) * b;
+            T l3 = (p1 != 0) && (b2 != 0) ? (log(p1) + log(b2)) * b : tools::max_value<T>();  // arbitrary large value if the logs would fail!
             if((l3 < tools::log_max_value<T>())
                && (l3 > tools::log_min_value<T>()))
             {

--- a/patches/0002-beta.hpp-prevent-ibeta_derivative-underflow-error.patch
+++ b/patches/0002-beta.hpp-prevent-ibeta_derivative-underflow-error.patch
@@ -1,0 +1,13 @@
+diff --git a/boost/math/special_functions/beta.hpp b/include/boost/math/special_functions/beta.hpp
+index 87e8950dc..f74937c1a 100644
+--- a/boost/math/special_functions/beta.hpp
++++ b/boost/math/special_functions/beta.hpp
+@@ -390,7 +390,7 @@ T ibeta_power_terms(T a,
+          else
+          {
+             T p1 = pow(b1, a / b);
+-            T l3 = (log(p1) + log(b2)) * b;
++            T l3 = (p1 != 0) && (b2 != 0) ? (log(p1) + log(b2)) * b : tools::max_value<T>();  // arbitrary large value if the logs would fail!
+             if((l3 < tools::log_max_value<T>())
+                && (l3 > tools::log_min_value<T>()))
+             {


### PR DESCRIPTION
- resolves `RuntimeWarning` raised due to taking `log(0)` when computing the PDF of the binomial distribution as reported in https://github.com/scipy/scipy/issues/15101
- upstream boost-math issue: https://github.com/boostorg/math/issues/799